### PR TITLE
Simplify user export to Backup view with import support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,34 @@ PotteryTracker/
 - Push branch and let user test before merging to main
 - Never commit directly to main
 
+## GitHub Issues Workflow
+
+When working on GitHub Issues, follow this process:
+
+### 1. Read Issue
+```bash
+gh issue view <number> --json title,body,comments
+gh issue list  # To see all open issues
+```
+
+### 2. Plan & Implement
+- Create a feature branch: `git checkout -b feature/issue-<number>-<short-description>`
+- Implement the changes according to the issue requirements
+- Follow verification steps (tests + build)
+
+### 3. Report Progress on Issue
+```bash
+# Add comment with implementation details
+gh issue comment <number> --body "Implementation complete: <summary of changes>"
+
+# Close issue when merged to main
+gh issue close <number>
+```
+
+### 4. Sub-Issues
+- Check if the issue has related sub-issues that should be addressed together
+- Reference parent issue in commits: `Fixes #<number>` or `Part of #<parent-number>`
+
 ## Important Patterns
 
 - **API Proxy**: Frontend dev server proxies `/api` to `localhost:3001`

--- a/backend/routes/export.js
+++ b/backend/routes/export.js
@@ -18,152 +18,6 @@ const upload = multer({
 // All export routes require authentication
 router.use(requireAuth);
 
-// Helper function to convert array to CSV
-function arrayToCSV(data) {
-  if (data.length === 0) return '';
-  
-  const headers = Object.keys(data[0]);
-  const csvRows = [headers.join(',')];
-  
-  for (const row of data) {
-    const values = headers.map(header => {
-      const value = row[header];
-      // Escape quotes and wrap in quotes if contains comma, quote, or newline
-      if (value == null) return '';
-      const stringValue = String(value);
-      if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
-        return `"${stringValue.replace(/"/g, '""')}"`;
-      }
-      return stringValue;
-    });
-    csvRows.push(values.join(','));
-  }
-  
-  return csvRows.join('\n');
-}
-
-// GET /api/export/pieces - Export pieces as CSV or JSON
-router.get('/pieces', async (req, res) => {
-  try {
-    const { format = 'json' } = req.query;
-    const db = await getDb();
-
-    // Get all pieces with related data
-    const pieces = await db.all(`
-      SELECT 
-        p.id,
-        p.name,
-        p.description,
-        p.done,
-        ph.name as phase_name,
-        p.created_at,
-        p.updated_at,
-        GROUP_CONCAT(DISTINCT m.name || ' (' || m.type || ')') as materials,
-        COUNT(DISTINCT pi.id) as image_count
-      FROM ceramic_pieces p
-      LEFT JOIN phases ph ON p.current_phase_id = ph.id AND ph.user_id = p.user_id
-      LEFT JOIN piece_materials pm ON p.id = pm.piece_id
-      LEFT JOIN materials m ON pm.material_id = m.id AND m.user_id = p.user_id
-      LEFT JOIN piece_images pi ON p.id = pi.piece_id
-      WHERE p.user_id = ?
-      GROUP BY p.id
-      ORDER BY p.created_at DESC
-    `, [req.userId]);
-
-
-    if (format === 'csv') {
-      res.setHeader('Content-Type', 'text/csv');
-      res.setHeader('Content-Disposition', `attachment; filename="pottery-pieces-${new Date().toISOString().split('T')[0]}.csv"`);
-      res.send(arrayToCSV(pieces));
-    } else {
-      res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Content-Disposition', `attachment; filename="pottery-pieces-${new Date().toISOString().split('T')[0]}.json"`);
-      res.json({
-        exportDate: new Date().toISOString(),
-        totalPieces: pieces.length,
-        pieces: pieces
-      });
-    }
-
-    logger.info('Pieces exported', {
-      format,
-      count: pieces.length,
-      userId: req.userId
-    });
-  } catch (error) {
-    logger.error('Error exporting pieces', {
-      error: error.message,
-      stack: error.stack,
-      userId: req.userId
-    });
-    res.status(500).json({ error: 'Failed to export pieces' });
-  }
-});
-
-// GET /api/export/stats - Get statistics/reports
-router.get('/stats', async (req, res) => {
-  try {
-    const db = await getDb();
-
-    // Get statistics
-    const stats = await db.get(`
-      SELECT 
-        COUNT(*) as total_pieces,
-        SUM(CASE WHEN done = 1 THEN 1 ELSE 0 END) as done_pieces,
-        SUM(CASE WHEN done = 0 THEN 1 ELSE 0 END) as in_progress_pieces,
-        COUNT(DISTINCT current_phase_id) as phases_in_use,
-        COUNT(DISTINCT pm.material_id) as materials_in_use,
-        COUNT(DISTINCT pi.id) as total_images
-      FROM ceramic_pieces p
-      LEFT JOIN piece_materials pm ON p.id = pm.piece_id
-      LEFT JOIN piece_images pi ON p.id = pi.piece_id
-      WHERE p.user_id = ?
-    `, [req.userId]);
-
-    // Get pieces by phase
-    const piecesByPhase = await db.all(`
-      SELECT 
-        ph.name as phase_name,
-        COUNT(*) as count
-      FROM ceramic_pieces p
-      LEFT JOIN phases ph ON p.current_phase_id = ph.id AND ph.user_id = p.user_id
-      WHERE p.user_id = ?
-      GROUP BY ph.id, ph.name
-      ORDER BY count DESC
-    `, [req.userId]);
-
-    // Get pieces by material type
-    const piecesByMaterialType = await db.all(`
-      SELECT 
-        m.type,
-        COUNT(DISTINCT p.id) as count
-      FROM ceramic_pieces p
-      INNER JOIN piece_materials pm ON p.id = pm.piece_id
-      INNER JOIN materials m ON pm.material_id = m.id AND m.user_id = p.user_id
-      WHERE p.user_id = ?
-      GROUP BY m.type
-      ORDER BY count DESC
-    `, [req.userId]);
-
-
-    res.json({
-      summary: stats,
-      piecesByPhase: piecesByPhase,
-      piecesByMaterialType: piecesByMaterialType,
-      generatedAt: new Date().toISOString()
-    });
-
-    logger.info('Statistics exported', { userId: req.userId });
-  } catch (error) {
-    logger.error('Error exporting statistics', {
-      error: error.message,
-      stack: error.stack,
-      userId: req.userId
-    });
-    res.status(500).json({ error: 'Failed to export statistics' });
-  }
-});
-
 // POST /api/export/archive - User export to archive
 router.post('/archive', async (req, res) => {
   try {
@@ -190,14 +44,14 @@ router.post('/archive', async (req, res) => {
 router.get('/archive/download/:filename', async (req, res) => {
   try {
     const { filename } = req.params;
-    
+
     // Verify filename belongs to this user (filename starts with user_{userId}_)
     if (!filename.startsWith(`user_${req.userId}_`)) {
       return res.status(403).json({ error: 'Access denied' });
     }
 
     const archivePath = getArchivePath( filename);
-    
+
     if (!existsSync(archivePath)) {
       return res.status(404).json({ error: 'Archive file not found' });
     }
@@ -255,4 +109,3 @@ router.post('/import', upload.single('file'), async (req, res) => {
 });
 
 export default router;
-

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -204,7 +204,7 @@ function AppContent() {
                 }
               />
               <Route
-                path="/export"
+                path="/backup"
                 element={
                   <ProtectedRoute>
                     <ExportData />

--- a/frontend/src/components/BottomNav.jsx
+++ b/frontend/src/components/BottomNav.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { LayoutDashboard, List, CheckCircle, Search, MoreVertical, Settings, Database, FileDown, Shield } from 'lucide-react';
+import { LayoutDashboard, List, CheckCircle, Search, MoreVertical, Settings, Database, Archive, Shield } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,7 +27,7 @@ function BottomNav() {
   const subMenuItems = [
     { path: '/workflow', icon: Settings, label: 'Workflow' },
     { path: '/materials', icon: Database, label: 'Materials' },
-    { path: '/export', icon: FileDown, label: 'Export' },
+    { path: '/backup', icon: Archive, label: 'Backup' },
     ...(isAdmin ? [{ path: '/admin', icon: Shield, label: 'Admin' }] : []),
   ];
 

--- a/frontend/src/components/ExportData.jsx
+++ b/frontend/src/components/ExportData.jsx
@@ -4,87 +4,35 @@ import { Button } from './ui/button';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from './ui/card';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
-import { Download, FileJson, FileSpreadsheet, BarChart3, Archive } from 'lucide-react';
+import { Download, Upload, Archive } from 'lucide-react';
 
 function ExportData() {
-  const [exporting, setExporting] = useState(false);
   const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
   const [archivePassword, setArchivePassword] = useState('');
   const [encryptArchive, setEncryptArchive] = useState(false);
   const [creatingArchive, setCreatingArchive] = useState(false);
 
-  const handleExport = async (format) => {
-    try {
-      setExporting(true);
-      setError(null);
-      
-      const response = await fetch(`/api/export/pieces?format=${format}`, {
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        throw new Error('Export failed');
-      }
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      
-      const contentDisposition = response.headers.get('Content-Disposition');
-      const filename = contentDisposition
-        ? contentDisposition.split('filename=')[1].replace(/"/g, '')
-        : `pottery-pieces.${format}`;
-      
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setExporting(false);
-    }
-  };
-
-  const handleExportStats = async () => {
-    try {
-      setExporting(true);
-      setError(null);
-      
-      const stats = await exportAPI.getStats();
-      
-      const blob = new Blob([JSON.stringify(stats, null, 2)], { type: 'application/json' });
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `pottery-stats-${new Date().toISOString().split('T')[0]}.json`;
-      document.body.appendChild(a);
-      a.click();
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setExporting(false);
-    }
-  };
+  // Import state
+  const [importFile, setImportFile] = useState(null);
+  const [importPassword, setImportPassword] = useState('');
+  const [importing, setImporting] = useState(false);
 
   const handleExportArchive = async () => {
     try {
       setCreatingArchive(true);
       setError(null);
-      
+      setSuccess(null);
+
       // Create archive (stored on server)
       const result = await exportAPI.exportArchive(encryptArchive ? archivePassword : undefined);
-      
+
       // Download the archive file
       const response = await exportAPI.downloadArchive(result.filename);
       if (!response.ok) {
         throw new Error('Failed to download archive');
       }
-      
+
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -94,10 +42,11 @@ function ExportData() {
       a.click();
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
-      
+
       // Reset form
       setArchivePassword('');
       setEncryptArchive(false);
+      setSuccess('Archive exported successfully');
     } catch (err) {
       setError(err.message || 'Failed to export archive');
     } finally {
@@ -105,9 +54,38 @@ function ExportData() {
     }
   };
 
+  const handleImportArchive = async () => {
+    if (!importFile) {
+      setError('Please select an archive file to import');
+      return;
+    }
+
+    try {
+      setImporting(true);
+      setError(null);
+      setSuccess(null);
+
+      await exportAPI.importArchive(importFile, importPassword || undefined);
+
+      setSuccess('Archive imported successfully! Your data has been restored.');
+      setImportFile(null);
+      setImportPassword('');
+
+      // Clear file input
+      const fileInput = document.getElementById('import-file');
+      if (fileInput) fileInput.value = '';
+    } catch (err) {
+      setError(err.message || 'Failed to import archive');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const isEncryptedFile = importFile?.name?.includes('.encrypted.');
+
   return (
     <div className="space-y-6">
-      <h2 className="text-2xl font-bold">Export Data</h2>
+      <h2 className="text-2xl font-bold">Backup</h2>
 
       {error && (
         <div className="p-3 rounded-md bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200 text-sm">
@@ -115,59 +93,20 @@ function ExportData() {
         </div>
       )}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Export Pieces</CardTitle>
-          <CardDescription>
-            Export all your pieces as CSV or JSON format.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex gap-3 flex-wrap">
-            <Button
-              onClick={() => handleExport('csv')}
-              disabled={exporting}
-              variant="outline"
-            >
-              <FileSpreadsheet className="mr-2 h-4 w-4" />
-              {exporting ? 'Exporting...' : 'Export as CSV'}
-            </Button>
-            <Button
-              onClick={() => handleExport('json')}
-              disabled={exporting}
-              variant="outline"
-            >
-              <FileJson className="mr-2 h-4 w-4" />
-              {exporting ? 'Exporting...' : 'Export as JSON'}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      {success && (
+        <div className="p-3 rounded-md bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-200 text-sm">
+          {success}
+        </div>
+      )}
 
       <Card>
         <CardHeader>
-          <CardTitle>Export Statistics</CardTitle>
+          <CardTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5" />
+            Export Archive
+          </CardTitle>
           <CardDescription>
-            Get a detailed report with statistics about your pieces.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button
-            onClick={handleExportStats}
-            disabled={exporting}
-            variant="outline"
-          >
-            <BarChart3 className="mr-2 h-4 w-4" />
-            {exporting ? 'Generating...' : 'Export Statistics'}
-          </Button>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Export Complete Archive</CardTitle>
-          <CardDescription>
-            Export all your data (pieces, materials, phases, images) as a ZIP archive. Includes a PDF report. Optionally encrypt with a password.
+            Export all your data (pieces, materials, phases, locations, images) as a ZIP archive. Optionally encrypt with a password for secure storage.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -200,6 +139,51 @@ function ExportData() {
           >
             <Archive className="mr-2 h-4 w-4" />
             {creatingArchive ? 'Creating Archive...' : 'Export Archive'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Upload className="h-5 w-5" />
+            Import Archive
+          </CardTitle>
+          <CardDescription>
+            Restore your data from a previously exported archive. If the archive is encrypted, provide the password used during export.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="import-file">Archive File</Label>
+            <Input
+              id="import-file"
+              type="file"
+              accept=".zip"
+              onChange={(e) => setImportFile(e.target.files?.[0] || null)}
+            />
+          </div>
+          {(isEncryptedFile || importPassword) && (
+            <div className="space-y-2">
+              <Label htmlFor="import-password">
+                Archive Password {isEncryptedFile && <span className="text-muted-foreground">(encrypted archive detected)</span>}
+              </Label>
+              <Input
+                id="import-password"
+                type="password"
+                value={importPassword}
+                onChange={(e) => setImportPassword(e.target.value)}
+                placeholder="Enter password to decrypt archive"
+              />
+            </div>
+          )}
+          <Button
+            onClick={handleImportArchive}
+            disabled={importing || !importFile || (isEncryptedFile && !importPassword)}
+            variant="outline"
+          >
+            <Upload className="mr-2 h-4 w-4" />
+            {importing ? 'Importing...' : 'Import Archive'}
           </Button>
         </CardContent>
       </Card>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { 
-  LayoutDashboard, 
-  List, 
-  CheckCircle, 
-  Settings, 
-  Database, 
-  FileDown, 
+import {
+  LayoutDashboard,
+  List,
+  CheckCircle,
+  Settings,
+  Database,
+  Archive,
   LogOut,
   Shield
 } from 'lucide-react';
@@ -26,7 +26,7 @@ function Sidebar() {
     { path: '/done', icon: CheckCircle, label: 'Done' },
     { path: '/workflow', icon: Settings, label: 'Workflow' },
     { path: '/materials', icon: Database, label: 'Materials' },
-    { path: '/export', icon: FileDown, label: 'Export' },
+    { path: '/backup', icon: Archive, label: 'Backup' },
     ...(isAdmin ? [{ path: '/admin', icon: Shield, label: 'Admin' }] : []),
   ];
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -215,13 +215,6 @@ export const imagesAPI = {
 
 // Export API
 export const exportAPI = {
-  exportPieces: (format = 'json') => {
-    // This will be handled by the component for file download
-    return fetch(`${API_BASE}/export/pieces?format=${format}`, {
-      credentials: 'include',
-    });
-  },
-  getStats: () => apiCall('/export/stats'),
   exportArchive: async (password) => {
     return apiCall('/export/archive', {
       method: 'POST',


### PR DESCRIPTION
## Summary

- Renamed the **Export** view to **Backup** with updated route (`/backup`), navigation labels, and Archive icon
- Removed the **Export Pieces** (CSV/JSON) and **Export Statistics** sections from the UI
- Removed corresponding unused backend endpoints (`/api/export/pieces`, `/api/export/stats`)
- Added **Import Archive** functionality allowing regular users to restore their data from previously exported archives (with optional password for encrypted archives)
- Updated `CLAUDE.md` with GitHub Issues workflow documentation

## Issues Resolved

- Fixes #5 - Simplification of user data export (parent issue)
- Fixes #6 - Remove crossed out sections
- Fixes #7 - Update Export functionality
- Fixes #8 - Add possibility to import an archive
- Fixes #9 - Rename the view to Backup

## Test plan

- [ ] Verify "Backup" navigation appears in sidebar and bottom nav
- [ ] Verify old `/export` route redirects or shows 404
- [ ] Test Export Archive with and without password encryption
- [ ] Test Import Archive with both encrypted and non-encrypted archives
- [ ] Verify admin export/import functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)